### PR TITLE
Fix `error[E0599]: no method named `description_` found for struct `KeyRejected` in the current scope`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,6 +132,11 @@ impl From<core::array::TryFromSliceError> for Unspecified {
 pub struct KeyRejected(&'static str);
 
 impl KeyRejected {
+    /// The value returned from <Self as std::error::Error>::description()
+    pub fn description_(&self) -> &'static str {
+        self.0
+    }
+
     pub(crate) fn inconsistent_components() -> Self {
         Self("InconsistentComponents")
     }


### PR DESCRIPTION
Both git master and 0.16.20 of upstream ring have

```
    /// The value returned from <Self as std::error::Error>::description()
    pub fn description_(&self) -> &'static str {
        self.0
    }
```

Adding this will solve [this](https://github.com/Keats/jsonwebtoken/issues/323) build failure in jsonwebtoken. I'm not quite sure how / why this snippet of code went missing in your fork, but here :)

PR for 0.16.20 branch following soon